### PR TITLE
Fix query params issue

### DIFF
--- a/firefly-iii/Dockerfile
+++ b/firefly-iii/Dockerfile
@@ -53,8 +53,8 @@ RUN \
         /var/www/firefly --strip-components=1 \
     && printf "vi_VN.UTF-8 UTF-8\nfi_FI.UTF-8 UTF-8\nsv_SE.UTF-8 UTF-8\nel_GR.UTF-8 UTF-8\nhu_HU.UTF-8 UTF-8\nro_RO.UTF-8 UTF-8\nnb_NO.UTF-8 UTF-8\nde_DE.UTF-8 UTF-8\ncs_CZ.UTF-8 UTF-8\nen_US.UTF-8 UTF-8\nes_ES.UTF-8 UTF-8\nfr_FR.UTF-8 UTF-8\nid_ID.UTF-8 UTF-8\nit_IT.UTF-8 UTF-8\nnl_NL.UTF-8 UTF-8\npl_PL.UTF-8 UTF-8\npt_PT.UTF-8 UTF-8\nru_RU.UTF-8 UTF-8\ntr_TR.UTF-8 UTF-8\nzh_TW.UTF-8 UTF-8\nzh_CN.UTF-8 UTF-8\n\n" > /etc/locale.gen \
     && locale-gen \
-#    && /tmp/composer install --prefer-dist --no-dev --no-scripts --no-suggest \
-#    && rm -f /tmp/composer \
+    && /tmp/composer install --prefer-dist --no-dev --no-scripts --no-suggest \
+    && rm -f /tmp/composer \
     && find /var/www/firefly -type f -name "*.md" -depth -exec rm -f {} \; \
     && chown -R www-data:www-data /var/www/firefly \
     && chmod -R 755 /var/www/firefly \

--- a/firefly-iii/rootfs/etc/nginx/includes/php.conf
+++ b/firefly-iii/rootfs/etc/nginx/includes/php.conf
@@ -1,4 +1,10 @@
 location ~ \.php$ {
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Forwarded-Server $host;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host $host;
+    client_max_body_size 64M;
     root /var/www/firefly/public;
     fastcgi_pass 127.0.0.1:9001;
     fastcgi_read_timeout 900;

--- a/firefly-iii/rootfs/etc/nginx/includes/server_params.conf
+++ b/firefly-iii/rootfs/etc/nginx/includes/server_params.conf
@@ -2,9 +2,9 @@ proxy_set_header X-Forwarded-For $remote_addr;
 
 add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 server_tokens off;
-server_name     $hostname;
+server_name $hostname;
 
-root            /var/www/firefly/public;
+root /var/www/firefly/public;
 
 client_max_body_size 300M;
 index index.html index.htm index.php;

--- a/firefly-iii/rootfs/etc/nginx/includes/server_params.conf
+++ b/firefly-iii/rootfs/etc/nginx/includes/server_params.conf
@@ -2,7 +2,7 @@ proxy_set_header X-Forwarded-For $remote_addr;
 
 add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 server_tokens off;
-#server_name     $hostname;
+server_name     $hostname;
 
 root            /var/www/firefly/public;
 
@@ -10,10 +10,10 @@ client_max_body_size 300M;
 index index.html index.htm index.php;
 
 add_header X-Content-Type-Options nosniff;
-#add_header X-XSS-Protection "1; mode=block";
+add_header X-XSS-Protection "1; mode=block";
 add_header X-Robots-Tag none;
 
-#autoindex off;
+autoindex off;
 
 location / {
     try_files $uri $uri/ /index.php?$query_string;
@@ -21,8 +21,9 @@ location / {
     sendfile off;
 }
 
-location ~* .(jpg|jpeg|png|gif|ico|css|js)$ {
+location ~* \.(jpg|jpeg|png|gif|ico|css|js)$ {
     expires 365d;
+    log_not_found off;
 }
 
 location ~ /\.ht {

--- a/firefly-iii/rootfs/etc/nginx/includes/server_params.conf
+++ b/firefly-iii/rootfs/etc/nginx/includes/server_params.conf
@@ -1,17 +1,24 @@
-server_name     $hostname;
+proxy_set_header X-Forwarded-For $remote_addr;
+
+add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+server_tokens off;
+#server_name     $hostname;
+
 root            /var/www/firefly/public;
-index           index.php;
+
+client_max_body_size 300M;
+index index.html index.htm index.php;
 
 add_header X-Content-Type-Options nosniff;
-add_header X-XSS-Protection "1; mode=block";
+#add_header X-XSS-Protection "1; mode=block";
 add_header X-Robots-Tag none;
 
-client_max_body_size 100M;
-
-autoindex off;
+#autoindex off;
 
 location / {
-    try_files $uri $uri/ /index.php?$is_args$args;
+    try_files $uri $uri/ /index.php?$query_string;
+    autoindex on;
+    sendfile off;
 }
 
 location ~* .(jpg|jpeg|png|gif|ico|css|js)$ {

--- a/firefly-iii/rootfs/etc/nginx/nginx.conf
+++ b/firefly-iii/rootfs/etc/nginx/nginx.conf
@@ -39,6 +39,7 @@ http {
     client_max_body_size    4G;
     default_type            application/octet-stream;
     gzip                    on;
+    gzip_types              text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
     keepalive_timeout       65;
     sendfile                on;
     server_tokens           off;


### PR DESCRIPTION
# Proposed Changes

Redo NGINX configs to fix API calls failing due to missing params, even though the parameters were being sent

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
